### PR TITLE
Fix templateId parameter typo

### DIFF
--- a/EmailSenderLib/TemplateRenderer/ITemplateRenderer.cs
+++ b/EmailSenderLib/TemplateRenderer/ITemplateRenderer.cs
@@ -5,8 +5,15 @@ namespace EmailSenderLib.TemplateRenderer;
 
 public interface ITemplateRenderer
 {
+    /// <summary>
+    /// Renders the specified template using provided data.
+    /// </summary>
+    /// <param name="templateId">Identifier of the template to render.</param>
+    /// <param name="data">Data used during template rendering.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>The rendered template content.</returns>
     public Task<RenderedContent> RenderTemplateAsync(
-        string tempalteId,
+        string templateId,
         object data,
         CancellationToken cancellationToken = default
     );


### PR DESCRIPTION
## Summary
- rename `tempalteId` parameter in `RenderTemplateAsync`
- add XML doc for `RenderTemplateAsync`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*